### PR TITLE
Allow sanity-nupic to choose the selected tab

### DIFF
--- a/examples/demos/org/numenta/sanity/demos/coordinates_2d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/coordinates_2d.cljs
@@ -200,7 +200,7 @@
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (set-model!))

--- a/examples/demos/org/numenta/sanity/demos/cortical_io.cljs
+++ b/examples/demos/org/numenta/sanity/demos/cortical_io.cljs
@@ -358,7 +358,7 @@ fox eat something.
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (put! into-sim ["run"]))

--- a/examples/demos/org/numenta/sanity/demos/fixed_seqs.cljs
+++ b/examples/demos/org/numenta/sanity/demos/fixed_seqs.cljs
@@ -133,6 +133,6 @@
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (set-model!))

--- a/examples/demos/org/numenta/sanity/demos/hotgym.cljs
+++ b/examples/demos/org/numenta/sanity/demos/hotgym.cljs
@@ -584,6 +584,6 @@
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (set-model!))

--- a/examples/demos/org/numenta/sanity/demos/letters.cljs
+++ b/examples/demos/org/numenta/sanity/demos/letters.cljs
@@ -181,7 +181,7 @@ Chifung has a friend."))
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (send-text!)
   (set-model!))

--- a/examples/demos/org/numenta/sanity/demos/q_learning_1d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/q_learning_1d.cljs
@@ -282,6 +282,6 @@
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (set-model!))

--- a/examples/demos/org/numenta/sanity/demos/q_learning_2d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/q_learning_2d.cljs
@@ -244,7 +244,7 @@
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (set-model!))

--- a/examples/demos/org/numenta/sanity/demos/runner.cljs
+++ b/examples/demos/org/numenta/sanity/demos/runner.cljs
@@ -31,13 +31,14 @@
               [key-value-display k v])))))
 
 (defn ^:export init
-  [title ws-url & feature-list]
+  [title ws-url selected-tab & feature-list]
   (let [into-sim-in (async/chan)
         into-sim-mult (async/mult into-sim-in)
         into-sim-eavesdrop (tap-c into-sim-mult)
         into-journal main/into-journal
         pipe-to-remote-target! (remote/init ws-url)
-        features (into #{} (map keyword) feature-list)]
+        features (into #{} (map keyword) feature-list)
+        current-tab (atom (keyword selected-tab))]
     (pipe-to-remote-target! "journal" into-journal)
     (pipe-to-remote-target! "simulation" (tap-c into-sim-mult))
 
@@ -48,6 +49,6 @@
         (recur)))
 
     (reagent/render [main/sanity-app title nil
-                     [world-pane main/steps main/selection] features
+                     [world-pane main/steps main/selection] current-tab features
                      into-sim-in]
                     (dom/getElement "sanity-app"))))

--- a/examples/demos/org/numenta/sanity/demos/second_level_motor.cljs
+++ b/examples/demos/org/numenta/sanity/demos/second_level_motor.cljs
@@ -223,7 +223,7 @@
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
 
   (set-model!))

--- a/examples/demos/org/numenta/sanity/demos/sensorimotor_1d.cljs
+++ b/examples/demos/org/numenta/sanity/demos/sensorimotor_1d.cljs
@@ -239,7 +239,7 @@
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (send-input-stream!)
   (set-model!))

--- a/examples/demos/org/numenta/sanity/demos/simple_sentences.cljs
+++ b/examples/demos/org/numenta/sanity/demos/simple_sentences.cljs
@@ -169,7 +169,7 @@
 (defn ^:export init
   []
   (reagent/render [main/sanity-app "Comportex" [model-tab] [world-pane]
-                   all-features into-sim]
+                   (atom :model) all-features into-sim]
                   (dom/getElement "sanity-app"))
   (send-text!)
   (set-model!))

--- a/src/org/numenta/sanity/controls_ui.cljs
+++ b/src/org/numenta/sanity/controls_ui.cljs
@@ -910,26 +910,24 @@
         ]])))
 
 (defn tabs
-  [tab-cmps]
-  (let [current-tab (atom (ffirst tab-cmps))]
-    (fn [tab-cmps]
-      [:div
-       [:nav
-        (into [:ul.nav.nav-tabs]
-              (for [[k _] tab-cmps]
-                [:li {:role "presentation"
-                      :class (if (= @current-tab k) "active")}
-                 [:a {:href "#"
-                      :on-click (fn [e]
-                                  (reset! current-tab k)
-                                  (.preventDefault e))}
-                  (name k)]]))]
-       [:div.tabs
-        (let [[_ cmp] (->> tab-cmps
-                           (filter (fn [[k _]]
-                                     (= @current-tab k)))
-                           first)]
-          cmp)]])))
+  [current-tab tab-cmps]
+  [:div
+   [:nav
+    (into [:ul.nav.nav-tabs]
+          (for [[k _] tab-cmps]
+            [:li {:role "presentation"
+                  :class (if (= @current-tab k) "active")}
+             [:a {:href "#"
+                  :on-click (fn [e]
+                              (reset! current-tab k)
+                              (.preventDefault e))}
+              (name k)]]))]
+   [:div.tabs
+    (let [[_ cmp] (->> tab-cmps
+                       (filter (fn [[k _]]
+                                 (= @current-tab k)))
+                       first)]
+      cmp)]])
 
 (defn help-block
   [show-help]
@@ -1062,7 +1060,7 @@
      [:hr]]))
 
 (defn sanity-app
-  [_ _ _ features _ _ selection steps network-shape _ _ _ into-journal _]
+  [_ _ _ features _ _ _ selection steps network-shape _ _ _ into-journal _]
   (let [show-help (atom false)
         viz-expanded (atom false)
         time-plots-tab (when (features :time-plots)
@@ -1070,8 +1068,9 @@
         cell-sdrs-tab (when (features :cell-SDRs)
                         (cell-sdrs-tab-builder steps network-shape selection
                                                into-journal))]
-    (fn [title model-tab main-pane _ capture-options viz-options selection steps
-         network-shape series-colors into-viz into-sim into-journal debug-data]
+    (fn [title model-tab main-pane _ capture-options viz-options current-tab
+         selection steps network-shape series-colors into-viz into-sim
+         into-journal debug-data]
       [:div
        [navbar title features steps show-help viz-options viz-expanded
         network-shape into-viz into-sim]
@@ -1082,6 +1081,7 @@
           main-pane]
          [:div.col-sm-3
           [tabs
+           current-tab
            (remove nil?
                    [(when model-tab
                       [:model model-tab])

--- a/src/org/numenta/sanity/main.cljs
+++ b/src/org/numenta/sanity/main.cljs
@@ -109,10 +109,10 @@
           into-viz into-sim into-journal]]]])))
 
 (defn sanity-app
-  [title model-tab world-pane features into-sim]
+  [title model-tab world-pane current-tab features into-sim]
   [cui/sanity-app title model-tab [main-pane world-pane into-sim]
-   features capture-options viz-options selection steps network-shape
-   viz/state-colors into-viz into-sim into-journal debug-data])
+   features capture-options viz-options current-tab selection steps
+   network-shape viz/state-colors into-viz into-sim into-journal debug-data])
 
 ;;; ## Exported helpers
 

--- a/src/org/numenta/sanity/viz_canvas.cljs
+++ b/src/org/numenta/sanity/viz_canvas.cljs
@@ -954,9 +954,7 @@
                                :ry (if sel? sel-ry ry)
                                :fill "black"
                                :fill-opacity (cond sel? 1.0 kept? 0.5 :else 0.1)}]
-                    (when (and (pos? (count steps))
-                               (or sel?
-                                   (and kept? (< keep-steps 100))))
+                    (when kept?
                       [:text {:x x-px :y y-px
                               :dy "0.35em"
                               :fill "white"}


### PR DESCRIPTION
Pull the "selected-tab" state out of the tabs component.

Explanation: In some situations I want "capture" to be selected by default. In others I want "drawing", especially when doing a patchTM, when conservative "capture" options are no longer needed.

This also changes the timeline to always show line numbers, even when there are lots of steps. I should have made that change when I made the timeline scrollable.